### PR TITLE
Updating dependency on laravel/nova

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "laravel/framework": "^7.0",
-        "laravel/nova": "^2.0",
+        "laravel/nova": "^3.0",
         "laravel/passport": "^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
There was a conflict in this libraries dependencies that prevented the package from being installed. Laravel Nova 2.x is not compatible with Laravel 7.x.

This change simply indicates that in addition to Laravel 7, we need Nova 3.